### PR TITLE
#111 Show graph sorted by bridge's priority

### DIFF
--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -7,5 +7,6 @@ class TopController < UserBaseController
     @matrix = Dashboard.matrix(@bridges)
     @overall_evaluations = Dashboard.sorted_overall_evaluations
     @soundness_chart = Dashboard.soundness_chart(@bridges)
+    @priority_chart = Dashboard.priority_chart(@bridges)
   end
 end

--- a/app/javascript/packs/apps/priority_chart.ts
+++ b/app/javascript/packs/apps/priority_chart.ts
@@ -1,0 +1,36 @@
+import Chart from 'chart.js'
+import colors from '../commons/colors'
+
+const chart_div = document.getElementById('priority_chart') as HTMLDivElement
+const ctx = document.getElementById('priority_chart_area') as HTMLCanvasElement
+
+const values = {}
+document.querySelectorAll('.priority_chart_value').forEach((element: HTMLSpanElement) => {
+  values[element.dataset.key_name] = parseInt(element.dataset.value)
+})
+
+const config = {
+  type: 'pie',
+  data: {
+    datasets: [{
+      data: Object.values(values),
+      backgroundColor: [
+        colors.blue,
+        colors.green,
+        colors.yellow,
+        colors.purple,
+      ],
+      label: chart_div.dataset.title
+    }],
+    labels: Object.keys(values)
+  },
+  options: {
+    responsive: true,
+    title: {
+      display: true,
+      text: chart_div.dataset.title
+    }
+  }
+}
+
+new Chart(ctx, config)

--- a/app/models/dashboard.rb
+++ b/app/models/dashboard.rb
@@ -30,6 +30,17 @@ class Dashboard
       values
     end
 
+    def priority_chart(bridges)
+      priority_types = Bridge.priority_types.map { |k, _| k }
+      values = {}
+      priority_types.each { |k| values[k.to_s] = 0 }
+      bridges.each do |bridge|
+        key = Bridge.priority_types.invert[bridge.priority]
+        values[key] += 1
+      end
+      values
+    end
+
     private
 
     def matrix_item(bridge)

--- a/app/views/top/index.html.slim
+++ b/app/views/top/index.html.slim
@@ -45,7 +45,12 @@
       - @soundness_chart.each do |key, value|
         span.soundness_chart_value[data-key=key data-value=value data-key_name=I18n.t("enums.soundness.overall_evaluation.#{key}")]
     .mdc-layout-grid__cell--span-6
+      #priority_chart[style="width: 100%" data-title=I18n.t('view.chart.priority')]
+        canvas#priority_chart_area
+      - @priority_chart.each do |key, value|
+        span.priority_chart_value[data-key=key data-value=value data-key_name=I18n.t("enums.bridge.priority_type.#{key}")]
 
 = javascript_pack_tag 'commons/data-table'
 = javascript_pack_tag 'map/bridges'
 = javascript_pack_tag 'apps/soundness_chart'
+= javascript_pack_tag 'apps/priority_chart'

--- a/config/locales/translation_en.yml
+++ b/config/locales/translation_en.yml
@@ -341,6 +341,7 @@ en:
 
     chart:
       soundness: "Soundness chart"
+      priority: "Priority chart"
 
   controller:
     common:

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -342,6 +342,7 @@ ja:
 
     chart:
       soundness: "健全性グラフ"
+      priority: "重要度グラフ"
 
   controller:
     common:

--- a/spec/models/dashboard_spec.rb
+++ b/spec/models/dashboard_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Dashboard, type: :model do
     FactoryBot.create(:soundness, bridge: @bridge3, evaluation_at: '2018/05/21', overall_evaluation: 'three')
     @bridges = Bridge.includes(:soundnesses)
   end
+
   describe 'matrix_item' do
     context 'call matrix' do
       it 'return values' do
@@ -36,12 +37,14 @@ RSpec.describe Dashboard, type: :model do
       end
     end
   end
+
   describe 'sorted_overall_evaluations' do
     it 'return sorted value' do
       result = Dashboard.sorted_overall_evaluations
       expect(result).to eq(%w[unselected four three two one])
     end
   end
+
   describe 'soundness_chart' do
     it 'return chart values' do
       result = Dashboard.soundness_chart(@bridges)
@@ -49,6 +52,13 @@ RSpec.describe Dashboard, type: :model do
       expect(result['one']).to eq(1)
       expect(result['two']).to eq(1)
       expect(result['three']).to eq(1)
+    end
+  end
+
+  describe 'priority_chart' do
+    it 'return priority values' do
+      result = Dashboard.priority_chart(@bridges)
+      expect(result['priority_unselected']).to eq(4)
     end
   end
 end


### PR DESCRIPTION
Fixes #111 .

Changes proposed in this pull request:
- Show graph sorted by bridge's priority

@ha4db/maintainer
