### PR TITLE
#122 rename observation to remark

### DIFF
--- a/app/controllers/diagnoses_controller.rb
+++ b/app/controllers/diagnoses_controller.rb
@@ -87,6 +87,6 @@ class DiagnosesController < UserBaseController
 
   # Only allow a list of trusted parameters through.
   def diagnosis_params
-    params.fetch(:diagnosis, {}).permit(:component_category, :result, :injury_id, :observation)
+    params.fetch(:diagnosis, {}).permit(:component_category, :result, :injury_id, :remark)
   end
 end

--- a/app/views/diagnoses/_form.html.slim
+++ b/app/views/diagnoses/_form.html.slim
@@ -19,7 +19,7 @@
   .mdc-layout-grid
     .mdc-layout-grid__inner
       .mdc-layout-grid__cell--span-12
-        = render partial: 'commons/mdc_outlined_text_field', locals: { f: f, model: Diagnosis, field_name: :observation }
+        = render partial: 'commons/mdc_outlined_text_field', locals: { f: f, model: Diagnosis, field_name: :remark }
 
   .mdc-layout-grid
     .mdc-layout-grid__inner

--- a/app/views/diagnoses/index.html.slim
+++ b/app/views/diagnoses/index.html.slim
@@ -16,7 +16,7 @@
                 th.mdc-data-table__header-cell[role="columnheader" scope="col"] = Diagnosis.human_attribute_name(:component_category)
                 th.mdc-data-table__header-cell[role="columnheader" scope="col"] = Diagnosis.human_attribute_name(:result)
                 th.mdc-data-table__header-cell[role="columnheader" scope="col"] = Diagnosis.human_attribute_name(:injury)
-                th.mdc-data-table__header-cell[role="columnheader" scope="col"] = Diagnosis.human_attribute_name(:observation)
+                th.mdc-data-table__header-cell[role="columnheader" scope="col"] = Diagnosis.human_attribute_name(:remark)
                 th.mdc-data-table__header-cell[role="columnheader" scope="col"]
                 th.mdc-data-table__header-cell[role="columnheader" scope="col"]
                 th.mdc-data-table__header-cell[role="columnheader" scope="col"]
@@ -28,7 +28,7 @@
                   td.mdc-data-table__cell = I18n.t("enums.component.category.#{Component.categories.key(diagnosis.component_category)}")
                   td.mdc-data-table__cell = I18n.t("enums.diagnosis.diagnosis_result.#{Diagnosis.diagnosis_results.key(diagnosis.result)}")
                   td.mdc-data-table__cell = diagnosis.injury && I18n.t("enums.component.category.#{Component.categories.invert[diagnosis.injury.component.component_category]}") + " #{diagnosis.injury.injury_type} #{diagnosis.injury.injury_grade}"
-                  td.mdc-data-table__cell = diagnosis.observation
+                  td.mdc-data-table__cell = diagnosis.remark
                   td.mdc-data-table__cell
                     = link_to 'visibility', [@regular_inspection, diagnosis], class: 'mdc-icon-button material-icons'
                   td.mdc-data-table__cell

--- a/app/views/diagnoses/show.html.slim
+++ b/app/views/diagnoses/show.html.slim
@@ -31,8 +31,8 @@
         li.mdc-list-item
           span.mdc-list-item__ripple
           span.mdc-list-item__text
-            span.mdc-list-item__primary-text = Diagnosis.human_attribute_name(:observation)
-            span.mdc-list-item__secondary-text = @diagnosis.observation
+            span.mdc-list-item__primary-text = Diagnosis.human_attribute_name(:remark)
+            span.mdc-list-item__secondary-text = @diagnosis.remark
   
 .mdc-layout-grid
   .mdc-layout-grid__inner

--- a/app/views/regular_inspections/show.html.slim
+++ b/app/views/regular_inspections/show.html.slim
@@ -113,7 +113,7 @@
                 th.mdc-data-table__header-cell[role="columnheader" scope="col"] = Diagnosis.human_attribute_name(:component_category)
                 th.mdc-data-table__header-cell[role="columnheader" scope="col"] = Diagnosis.human_attribute_name(:result)
                 th.mdc-data-table__header-cell[role="columnheader" scope="col"] = Diagnosis.human_attribute_name(:injury)
-                th.mdc-data-table__header-cell[role="columnheader" scope="col"] = Diagnosis.human_attribute_name(:observation)
+                th.mdc-data-table__header-cell[role="columnheader" scope="col"] = Diagnosis.human_attribute_name(:remark)
                 th.mdc-data-table__header-cell[role="columnheader" scope="col"] = I18n.t("view.title.note")
  
             tbody.mdc-data-table__content
@@ -123,7 +123,7 @@
                   td.mdc-data-table__cell = I18n.t("enums.component.category.#{Component.categories.key(diagnosis.component_category)}")
                   td.mdc-data-table__cell = I18n.t("enums.diagnosis.diagnosis_result.#{Diagnosis.diagnosis_results.key(diagnosis.result)}")
                   td.mdc-data-table__cell = diagnosis.injury && I18n.t("enums.component.category.#{Component.categories.invert[diagnosis.injury.component.component_category]}") + " #{diagnosis.injury.injury_type} #{diagnosis.injury.injury_grade}"
-                  td.mdc-data-table__cell = diagnosis.observation
+                  td.mdc-data-table__cell = diagnosis.remark
                   td.mdc-data-table__cell
                     - unless diagnosis.injury.nil?
                       span.note = I18n.t("view.title.status")

--- a/config/locales/translation_en.yml
+++ b/config/locales/translation_en.yml
@@ -167,7 +167,7 @@ en:
       diagnosis:
         component_category: Component category
         injury: :activerecord.models.injury
-        observation: Observation
+        remark: Remark
         other_data: Other data
         regular_inspection: :activerecord.models.regular_inspection
         result: Result

--- a/config/locales/translation_ja.yml
+++ b/config/locales/translation_ja.yml
@@ -168,7 +168,7 @@ ja:
         component_category: 部材の種類
         injury: :activerecord.models.injury
         injury_id: :activerecord.models.injury
-        observation: 所見
+        remark: 備考
         other_data: その他のデータ
         regular_inspection: :activerecord.models.regular_inspection
         result: 判定区分

--- a/db/migrate/20210226005813_change_column_name_in_diagnoses_from_observation_to_remark.rb
+++ b/db/migrate/20210226005813_change_column_name_in_diagnoses_from_observation_to_remark.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# ChangeColumnNameInDiagnosesFromObservationToRemark Migrate
+class ChangeColumnNameInDiagnosesFromObservationToRemark < ActiveRecord::Migration[6.0]
+  def change
+    rename_column :diagnoses, :observation, :remark
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_17_012723) do
+ActiveRecord::Schema.define(version: 2021_02_26_005813) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -99,7 +99,7 @@ ActiveRecord::Schema.define(version: 2021_02_17_012723) do
     t.integer "component_category"
     t.integer "result"
     t.bigint "injury_id"
-    t.string "observation"
+    t.string "remark"
     t.jsonb "other_data"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/doc/er.dot
+++ b/doc/er.dot
@@ -21,7 +21,7 @@ digraph models {
   bridge_contents [label="bridge_contents(橋のコンテンツ)|{{id|regular_inspection_id|component_id|title(名前)|data(画像/動画)|metadata(データの内部構造)|created_at|updated_at}|{Int|Int|Int|0String|ActiveStroage|Jsonb|Datetime|Datetime}}"]
 
   // 定期点検 -> 診断結果 diagnosises // 判定区分2〜3のときにinjuriesを参照する(現在は一つのみ)
-  diagnoses [label="diagnoses(診断結果)|{{id|regular_inspection_id|component_category(部材の種類)|result(判定区分(1〜3))|injury_id(損傷状況)|observation(所見)}|{Int|Int|Enum.ComponentCategory|Int|Int|String}}"];
+  diagnoses [label="diagnoses(診断結果)|{{id|regular_inspection_id|component_category(部材の種類)|result(判定区分(1〜3))|injury_id(損傷状況)|remark(備考)}|{Int|Int|Enum.ComponentCategory|Int|Int|String}}"];
   // 定期点検 -> 損傷状況 injuries
   injuries [label="injuries(損傷状況)|{{id|regular_inspection_id|component_id|injury_type(損傷の種類)|injury_grade(損傷程度)|other_data}|{Int|Int|Int|String|Int|jsonb}}"];
   bridge_content_injuries [label="bridge_content_injuries(中間テーブル)|{{id|bridge_content_id|injury_id|other_data}|{Int|Int|Int|jsonb}}"];

--- a/spec/factories/diagnoses.rb
+++ b/spec/factories/diagnoses.rb
@@ -6,6 +6,6 @@ FactoryBot.define do
     component_category { Component.categories[:superstructure_main_girder] }
     result { Diagnosis.diagnosis_results[:one] }
     injury { nil }
-    sequence(:observation) { |i| "observation #{i}" }
+    sequence(:remark) { |i| "remark #{i}" }
   end
 end

--- a/spec/models/diagnosis_spec.rb
+++ b/spec/models/diagnosis_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Diagnosis, type: :model do
   it { should respond_to(:component_category) }
   it { should respond_to(:result) }
   it { should respond_to(:injury) }
-  it { should respond_to(:observation) }
+  it { should respond_to(:remark) }
 
   it { should be_valid }
 


### PR DESCRIPTION
Fixes #122 .

Changes proposed in this pull request:
- rename observation to remark

@ha4db/maintainer
